### PR TITLE
Debug build

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -8,17 +8,23 @@ OBJDIR = $(FOCAL_DIR)/obj/
 MODDIR = $(FOCAL_DIR)/mod/
 
 # --- Targets ---
-FOCAL_LIB = $(FOCAL_DIR)/lib/libfocal.a
+FOCAL_LIB = $(addprefix $(FOCAL_DIR)/lib/, libfocal.a libfocaldbg.a)
 EXEC = $(addprefix $(BINDIR), $(PROGS))
 DIRS = $(MODDIR) $(BINDIR) $(OBJDIR)
 
-# --- Link Flags ---
-FOCAL_LFLAGS ?= -L$(FOCAL_DIR)/lib -lfocal
-OPENCL_LFLAGS ?= -L$(OPENCL_DIR) -lOpenCL
-LFLAGS = $(FOCAL_LFLAGS) $(OPENCL_LFLAGS)
-
 # --- Compiler Flags ---
 include $(FOCAL_DIR)/make.compiler
+
+# --- Link Flags ---
+ifeq ($(BUILD), release)
+    FOCAL_LFLAGS ?= -L$(FOCAL_DIR)/lib -lfocal
+else ifeq ($(BUILD), debug)
+    FOCAL_LFLAGS ?= -L$(FOCAL_DIR)/lib -lfocaldbg
+else
+    $(error unrecognized build.)
+endif
+OPENCL_LFLAGS ?= -g -L$(OPENCL_DIR) -lOpenCL 
+LFLAGS = $(FOCAL_LFLAGS) $(OPENCL_LFLAGS)
 
 # --- Recipes ---
 all: $(DIRS) $(EXEC)
@@ -26,12 +32,15 @@ all: $(DIRS) $(EXEC)
 clean:
 	rm -f $(EXEC)
 
+# Executables are dependent on focal libs
+#$(EXEC): $(FOCAL_LIB)
+
 # Link executables
-$(BINDIR)%: $(addprefix $(OBJDIR), %.o) fclKernels.o $(FOCAL_LIB)
+$(BINDIR)%: $(addprefix $(OBJDIR), %.o) fclKernels.o 
 	$(FC) $^ $(LFLAGS) -o $@
 
 # Compile fortran objects
-$(OBJDIR)%.o: %.f90 
+$(OBJDIR)%.o: %.f90 $(FOCAL_LIB)
 	$(FC) $(FFLAGS) -c $< -o $@
 
 # Compile kernel binary resource

--- a/external/clfortran/clfortran.f90
+++ b/external/clfortran/clfortran.f90
@@ -19,6 +19,7 @@
 ! Modified by: LKedward 2019
 !  Add explicit definition of 'BOZ' constants as integers.
 !  Fix interface definitions to be in interface block.
+!  Add definitions of cl_event_command_execution_status constants
 !
 ! https://github.com/LKedward/clfortran
 !
@@ -104,7 +105,7 @@ module clfortran
     integer(c_int32_t), parameter :: CL_INVALID_COMPILER_OPTIONS                  = -66
     integer(c_int32_t), parameter :: CL_INVALID_LINKER_OPTIONS                    = -67
     integer(c_int32_t), parameter :: CL_INVALID_DEVICE_PARTITION_COUNT            = -68
-    
+
     ! OpenCL Version
     integer(c_int32_t), parameter :: CL_VERSION_1_0                               = 1
     integer(c_int32_t), parameter :: CL_VERSION_1_1                               = 1
@@ -308,7 +309,7 @@ module clfortran
     integer(c_int32_t), parameter :: CL_MEM_OBJECT_IMAGE1D                      = int(Z'10F4',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_MEM_OBJECT_IMAGE1D_ARRAY                = int(Z'10F5',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_MEM_OBJECT_IMAGE1D_BUFFER               = int(Z'10F6',kind=c_int32_t)
-    
+
     ! cl_mem_info
     integer(c_int32_t), parameter :: CL_MEM_TYPE                                = int(Z'1100',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_MEM_FLAGS                               = int(Z'1101',kind=c_int32_t)
@@ -332,26 +333,26 @@ module clfortran
     integer(c_int32_t), parameter :: CL_IMAGE_INFO_BUFFER                       = int(Z'1118',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_IMAGE_INFO_NUM_MIP_LEVELS               = int(Z'1119',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_IMAGE_INFO_NUM_SAMPLES                  = int(Z'111A',kind=c_int32_t)
-    
+
     ! cl_addressing_mode
     integer(c_int32_t), parameter :: CL_ADDRESS_NONE                            = int(Z'1130',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_ADDRESS_CLAMP_TO_EDGE                   = int(Z'1131',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_ADDRESS_CLAMP                           = int(Z'1132',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_ADDRESS_REPEAT                          = int(Z'1133',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_ADDRESS_MIRRORED_REPEAT                 = int(Z'1134',kind=c_int32_t)
-    
-    ! cl_filter_mode                                                              
+
+    ! cl_filter_mode
     integer(c_int32_t), parameter :: CL_FILTER_NEAREST                          = int(Z'1140',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_FILTER_LINEAR                           = int(Z'1141',kind=c_int32_t)
-    
-    ! cl_sampler_info                                                            
+
+    ! cl_sampler_info
     integer(c_int32_t), parameter :: CL_SAMPLER_REFERENCE_COUNT                 = int(Z'1150',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_SAMPLER_CONTEXT                         = int(Z'1151',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_SAMPLER_NORMALIZED_COORDS               = int(Z'1152',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_SAMPLER_ADDRESSING_MODE                 = int(Z'1153',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_SAMPLER_FILTER_MODE                     = int(Z'1154',kind=c_int32_t)
-    
-    ! cl_program_info                                                             
+
+    ! cl_program_info
     integer(c_int32_t), parameter :: CL_PROGRAM_REFERENCE_COUNT                 = int(Z'1160',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_CONTEXT                         = int(Z'1161',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_NUM_DEVICES                     = int(Z'1162',kind=c_int32_t)
@@ -361,14 +362,14 @@ module clfortran
     integer(c_int32_t), parameter :: CL_PROGRAM_BINARIES                        = int(Z'1166',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_NUM_KERNELS                     = int(Z'1167',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_KERNEL_NAMES                    = int(Z'1168',kind=c_int32_t)
-    
-    ! cl_program_build_info                                                      
+
+    ! cl_program_build_info
     integer(c_int32_t), parameter :: CL_PROGRAM_BUILD_STATUS                    = int(Z'1181',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_BUILD_OPTIONS                   = int(Z'1182',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_BUILD_LOG                       = int(Z'1183',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_BINARY_TYPE                     = int(Z'1184',kind=c_int32_t)
-    
-    ! cl_program_binary_type                                                      
+
+    ! cl_program_binary_type
     integer(c_int32_t), parameter :: CL_PROGRAM_BINARY_TYPE_NONE                = int(Z'0',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT     = int(Z'1',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROGRAM_BINARY_TYPE_LIBRARY             = int(Z'2',kind=c_int32_t)
@@ -379,7 +380,7 @@ module clfortran
     integer(c_int32_t), parameter :: CL_BUILD_NONE                              = -1
     integer(c_int32_t), parameter :: CL_BUILD_ERROR                             = -2
     integer(c_int32_t), parameter :: CL_BUILD_IN_PROGRESS                       = -3
-    
+
     ! cl_kernel_info
     integer(c_int32_t), parameter :: CL_KERNEL_FUNCTION_NAME                    = int(Z'1190',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_KERNEL_NUM_ARGS                         = int(Z'1191',kind=c_int32_t)
@@ -406,7 +407,7 @@ module clfortran
     integer(c_int32_t), parameter :: CL_KERNEL_ARG_ACCESS_WRITE_ONLY            = int(Z'11A1',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_KERNEL_ARG_ACCESS_READ_WRITE            = int(Z'11A2',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_KERNEL_ARG_ACCESS_NONE                  = int(Z'11A3',kind=c_int32_t)
-    
+
     ! cl_kernel_arg_type_qualifer - bitfield (int64)
     integer(c_int64_t), parameter :: CL_KERNEL_ARG_TYPE_NONE                    = int(b'000',kind=c_int64_t)
     integer(c_int64_t), parameter :: CL_KERNEL_ARG_TYPE_CONST                   = int(b'001',kind=c_int64_t)
@@ -420,26 +421,31 @@ module clfortran
     integer(c_int32_t), parameter :: CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE=int(Z'11B3',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_KERNEL_PRIVATE_MEM_SIZE                 = int(Z'11B4',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_KERNEL_GLOBAL_WORK_SIZE                 = int(Z'11B5',kind=c_int32_t)
-    
+
     ! cl_event_info
     integer(c_int32_t), parameter :: CL_EVENT_COMMAND_QUEUE                     = int(Z'11D0',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_EVENT_COMMAND_TYPE                      = int(Z'11D1',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_EVENT_REFERENCE_COUNT                   = int(Z'11D2',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_EVENT_COMMAND_EXECUTION_STATUS          = int(Z'11D3',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_EVENT_CONTEXT                           = int(Z'11D4',kind=c_int32_t)
-    
+
     ! cl_profiling_info
     integer(c_int32_t), parameter :: CL_PROFILING_COMMAND_QUEUED                = int(Z'1280',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROFILING_COMMAND_SUBMIT                = int(Z'1281',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROFILING_COMMAND_START                 = int(Z'1282',kind=c_int32_t)
     integer(c_int32_t), parameter :: CL_PROFILING_COMMAND_END                   = int(Z'1283',kind=c_int32_t)
-    
-    
-    type, BIND(C) :: cl_image_format 
+
+    ! cl_event_command_execution_status
+    integer(c_int32_t), parameter :: CL_COMPLETE                                = int(Z'0',kind=c_int32_t)
+    integer(c_int32_t), parameter :: CL_RUNNING                                 = int(Z'1',kind=c_int32_t)
+    integer(c_int32_t), parameter :: CL_SUBMITTED                               = int(Z'2',kind=c_int32_t)
+    integer(c_int32_t), parameter :: CL_QUEUED                                  = int(Z'3',kind=c_int32_t)
+
+    type, BIND(C) :: cl_image_format
         integer(c_int32_t) :: image_channel_order
         integer(c_int32_t) :: image_channel_data_type
     end type cl_image_format
-    
+
     type, BIND(C) :: cl_image_desc
         integer(c_int32_t)  :: image_type
         integer(c_size_t)   :: image_width
@@ -457,7 +463,7 @@ module clfortran
     ! Start interfaces.
     !
 !    contains
-    
+
     interface
 !    ! ------------
 !    ! Platform API
@@ -761,12 +767,12 @@ module clfortran
             integer(c_int32_t), intent(out) :: errcode_ret
 
         end function
-                        
+
     ! clRetainMemObject
         integer(c_int32_t) function clRetainMemObject(mem_obj) &
             BIND(C, NAME='clRetainMemObject')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value  :: mem_obj
 
@@ -776,7 +782,7 @@ module clfortran
         integer(c_int32_t) function clReleaseMemObject(mem_obj) &
             BIND(C, NAME='clReleaseMemObject')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value  :: mem_obj
 
@@ -791,7 +797,7 @@ module clfortran
                 num_image_formats) &
             BIND(C, NAME='clGetSupportedImageFormats')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value  :: context
             integer(c_int64_t), value   :: flags
@@ -801,7 +807,7 @@ module clfortran
             integer(c_int32_t), intent(out) :: num_image_formats
 
         end function
-        
+
     ! clGetMemObjectInfo
         integer(c_int32_t) function clGetMemObjectInfo(memobj, &
                  param_name, &
@@ -819,7 +825,7 @@ module clfortran
             integer(c_size_t), intent(out) :: param_value_size_ret
 
         end function
-        
+
     ! clGetImageInfo
         integer(c_int32_t) function clGetImageInfo(image, &
                  param_name, &
@@ -828,7 +834,7 @@ module clfortran
                  param_value_size_ret) &
             BIND(C, NAME='clGetImageInfo')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: image
             integer(c_int32_t), value  :: param_name
@@ -855,7 +861,7 @@ module clfortran
     ! ------------
     ! Sampler APIs
     ! ------------
-    
+
     ! clCreateSampler
         integer(c_intptr_t) function clCreateSampler(context, &
                 normalized_coords, &
@@ -864,36 +870,36 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clCreateSampler')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: context
             integer(c_int32_t), value :: normalized_coords
-            integer(c_int32_t), value :: addressing_mode 
+            integer(c_int32_t), value :: addressing_mode
             integer(c_int32_t), value :: filter_mode
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
-        
+
     ! clRetainSampler
         integer(c_int32_t) function clRetainSampler(sampler) &
             BIND(C, NAME='clRetainSampler')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: sampler
-            
+
         end function
 
     ! clReleaseSampler
         integer(c_int32_t) function clReleaseSampler(sampler) &
             BIND(C, NAME='clReleaseSampler')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: sampler
-            
+
         end function
-        
+
     ! clGetSamplerInfo
         integer(c_int32_t) function clGetSamplerInfo(sampler, &
                  param_name, &
@@ -911,11 +917,11 @@ module clfortran
             integer(c_size_t), intent(out) :: param_value_size_ret
 
         end function
-        
+
     ! -------------------
     ! Program Object APIs
     ! -------------------
-    
+
     ! clCreateProgramWithSource
         integer(c_intptr_t) function clCreateProgramWithSource(context, &
                 count, &
@@ -924,14 +930,14 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clCreateProgramWithSource')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: context
             integer(c_int32_t), value :: count
             type(c_ptr), value :: strings
             type(c_ptr), value :: lengths
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clCreateProgramWithBinary
@@ -944,7 +950,7 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clCreateProgramWithBinary')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: context
             integer(c_int32_t), value :: num_devices
@@ -953,7 +959,7 @@ module clfortran
             type(c_ptr), value :: binaries
             type(c_ptr), value :: binary_status
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clCreateProgramWithBuiltInKernels
@@ -964,34 +970,34 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clCreateProgramWithBuiltInKernels')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: context
             integer(c_int32_t), value :: num_devices
             type(c_ptr), value :: device_list
             type(c_ptr), value :: kernel_names
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clRetainProgram
         integer(c_int32_t) function clRetainProgram(program) &
             BIND(C, NAME='clRetainProgram')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: program
-            
+
         end function
 
     ! clReleaseProgram
         integer(c_int32_t) function clReleaseProgram(program) &
             BIND(C, NAME='clReleaseProgram')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: program
-            
+
         end function
 
     ! clBuildProgram
@@ -1003,7 +1009,7 @@ module clfortran
                 user_data) &
             BIND(C, NAME='clBuildProgram')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: program
             integer(c_int32_t), value :: num_devices
@@ -1011,7 +1017,7 @@ module clfortran
             type(c_ptr), value :: options
             type(c_funptr), value :: pfn_notify
             type(c_ptr), value :: user_data
-            
+
         end function
 
     ! clCompileProgram
@@ -1026,7 +1032,7 @@ module clfortran
                 user_data) &
             BIND(C, NAME='clCompileProgram')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: program
             integer(c_int32_t), value :: num_devices
@@ -1037,7 +1043,7 @@ module clfortran
             type(c_ptr), value :: header_include_names
             type(c_funptr), value :: pfn_notify
             type(c_ptr), value :: user_data
-            
+
         end function
 
     ! clLinkProgram
@@ -1052,7 +1058,7 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clLinkProgram')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: context
             integer(c_int32_t), value :: num_devices
@@ -1063,17 +1069,17 @@ module clfortran
             type(c_funptr), value :: pfn_notify
             type(c_ptr), value :: user_data
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clUnloadPlatformCompiler
         integer(c_int32_t) function clUnloadPlatformCompiler(platform) &
             BIND(C, NAME='clUnloadPlatformCompiler')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: platform
-            
+
         end function
 
     ! clGetProgramInfo
@@ -1117,19 +1123,19 @@ module clfortran
     ! ------------------
     ! Kernel Object APIs
     ! ------------------
-    
+
     ! clCreateKernel
         integer(c_intptr_t) function clCreateKernel(program, &
                 kernel_name, &
                 errcode_ret) &
             BIND(C, NAME='clCreateKernel')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: program
             type(c_ptr), value :: kernel_name
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clCreateKernelsInProgram
@@ -1139,35 +1145,35 @@ module clfortran
                 num_kernels_ret) &
             BIND(C, NAME='clCreateKernelsInProgram')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: program
             integer(c_int32_t), value :: num_kernels
             type(c_ptr), value :: kernels
             integer(c_int32_t), intent(out) :: num_kernels_ret
-            
+
         end function
 
     ! clRetainKernel
         integer(c_int32_t) function clRetainKernel(kernel) &
             BIND(C, NAME='clRetainKernel')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: kernel
-            
+
         end function
 
     ! clReleaseKernel
         integer(c_int32_t) function clReleaseKernel(kernel) &
             BIND(C, NAME='clReleaseKernel')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: kernel
-            
+
         end function
-        
+
     ! clSetKernelArg
         integer(c_int32_t) function clSetKernelArg(kernel, &
                 arg_index, &
@@ -1175,13 +1181,13 @@ module clfortran
                 arg_value) &
             BIND(C, NAME='clSetKernelArg')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: kernel
             integer(c_int32_t), value :: arg_index
             integer(c_size_t), value :: arg_size
             type(c_ptr), value :: arg_value
-            
+
         end function
 
     ! clGetKernelInfo
@@ -1245,17 +1251,17 @@ module clfortran
     ! -----------------
     ! Event Object APIs
     ! -----------------
-    
+
     ! clWaitForEvents
         integer(c_int32_t) function clWaitForEvents(num_events, &
                 event_list) &
             BIND(C, NAME='clWaitForEvents')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_int32_t), value :: num_events
             type(c_ptr), value :: event_list
-            
+
         end function
 
     ! clGetEventInfo
@@ -1281,31 +1287,31 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clCreateUserEvent')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_int32_t), value :: context
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clRetainEvent
         integer(c_int32_t) function clRetainEvent(event) &
             BIND(C, NAME='clRetainEvent')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: event
-            
+
         end function
 
     ! clReleaseEvent
         integer(c_int32_t) function clReleaseEvent(event) &
             BIND(C, NAME='clReleaseEvent')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: event
-            
+
         end function
 
     ! clSetUserEventStatus
@@ -1313,11 +1319,11 @@ module clfortran
                 execution_status) &
             BIND(C, NAME='clSetUserEventStatus')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: event
             integer(c_int32_t), value :: execution_status
-            
+
         end function
 
     ! clSetEventCallback
@@ -1327,13 +1333,13 @@ module clfortran
                 user_data) &
             BIND(C, NAME='clSetEventCallback')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: event
             integer(c_int32_t), value :: command_exec_callback_type
             type(c_funptr), value :: pfn_notify
             type(c_ptr), value :: user_data
-            
+
         end function
 
     ! --------------
@@ -1381,11 +1387,11 @@ module clfortran
             integer(c_intptr_t), value :: command_queue
 
         end function
-    
+
     ! ----------------------
     ! Enqueued Commands APIs
     ! ----------------------
-    
+
     ! clEnqueueReadBuffer
         integer(c_int32_t) function clEnqueueReadBuffer(command_queue, &
                 buffer, &
@@ -1398,7 +1404,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueReadBuffer')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: buffer
@@ -1409,9 +1415,9 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
-    
+
     ! clEnqueueReadBufferRect
         integer(c_int32_t) function clEnqueueReadBufferRect(command_queue, &
                 buffer, &
@@ -1422,17 +1428,17 @@ module clfortran
                 buffer_row_pitch, &
                 buffer_slice_pitch, &
                 host_row_pitch, &
-                host_slice_pitch, &                      
+                host_slice_pitch, &
                 ptr, &
                 num_events_in_wait_list, &
                 event_wait_list, &
                 event) &
             BIND(C, NAME='clEnqueueReadBufferRect')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
-            
+
             integer(c_intptr_t), value :: buffer
             integer(c_int32_t), value :: blocking_read
             type(c_ptr), value :: buffer_offset
@@ -1446,7 +1452,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueWriteBuffer
@@ -1461,7 +1467,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueWriteBuffer')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: buffer
@@ -1472,7 +1478,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueWriteBufferRect
@@ -1485,14 +1491,14 @@ module clfortran
                 buffer_row_pitch, &
                 buffer_slice_pitch, &
                 host_row_pitch, &
-                host_slice_pitch, &                      
+                host_slice_pitch, &
                 ptr, &
                 num_events_in_wait_list, &
                 event_wait_list, &
                 event) &
             BIND(C, NAME='clEnqueueWriteBufferRect')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: buffer
@@ -1508,7 +1514,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueFillBuffer
@@ -1523,7 +1529,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueFillBuffer')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: buffer
@@ -1534,7 +1540,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueCopyBuffer
@@ -1549,7 +1555,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueCopyBuffer')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: src_buffer
@@ -1560,7 +1566,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueCopyBufferRect
@@ -1579,7 +1585,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueCopyBufferRect')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: src_buffer
@@ -1594,7 +1600,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueReadImage
@@ -1611,7 +1617,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueReadImage')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: image
@@ -1624,7 +1630,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueWriteImage
@@ -1641,7 +1647,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueWriteImage')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: image
@@ -1654,7 +1660,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueFillImage
@@ -1668,7 +1674,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueFillImage')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: image
@@ -1678,7 +1684,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueCopyImage
@@ -1693,7 +1699,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueCopyImage')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: src_image
@@ -1704,7 +1710,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueCopyImageToBuffer
@@ -1719,7 +1725,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueCopyImageToBuffer')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: src_image
@@ -1730,7 +1736,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueCopyBufferToImage
@@ -1745,7 +1751,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueCopyBufferToImage')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: src_buffer
@@ -1756,7 +1762,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueMapBuffer
@@ -1772,7 +1778,7 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clEnqueueMapBuffer')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: buffer
@@ -1784,7 +1790,7 @@ module clfortran
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clEnqueueMapImage
@@ -1802,7 +1808,7 @@ module clfortran
                 errcode_ret) &
             BIND(C, NAME='clEnqueueMapImage')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: image
@@ -1816,7 +1822,7 @@ module clfortran
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
             integer(c_int32_t), intent(out) :: errcode_ret
-            
+
         end function
 
     ! clEnqueueUnmapMemObject
@@ -1828,7 +1834,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueUnmapMemObject')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: memobj
@@ -1836,7 +1842,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueMigrateMemObjects
@@ -1849,7 +1855,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueMigrateMemObjects')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_int32_t), value :: num_mem_objects
@@ -1858,7 +1864,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueNDRangeKernel.
@@ -1873,7 +1879,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueNDRangeKernel')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: kernel
@@ -1884,7 +1890,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueTask
@@ -1895,14 +1901,14 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueTask')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_intptr_t), value :: kernel
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueNativeKernel
@@ -1918,7 +1924,7 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueNativeKernel')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             type(c_funptr), value :: user_func
@@ -1930,7 +1936,7 @@ module clfortran
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueMarkerWithWaitList
@@ -1940,13 +1946,13 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueMarkerWithWaitList')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clEnqueueMarkerWithWaitList
@@ -1956,13 +1962,13 @@ module clfortran
                 event) &
             BIND(C, NAME='clEnqueueBarrierWithWaitList')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: command_queue
             integer(c_int32_t), value :: num_events_in_wait_list
             type(c_ptr), value :: event_wait_list
             type(c_ptr), value :: event
-            
+
         end function
 
     ! clSetPrintfCallback
@@ -1971,14 +1977,14 @@ module clfortran
                 user_data) &
             BIND(C, NAME='clSetPrintfCallback')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: context
             type(c_funptr), value :: pfn_notify
             type(c_ptr), value :: user_data
-            
+
         end function
-    
+
     ! -------------------------
     ! Extension function access
     ! -------------------------
@@ -1986,13 +1992,13 @@ module clfortran
                 func_name) &
             BIND(C, NAME='clGetExtensionFunctionAddressForPlatform')
             USE ISO_C_BINDING
-            
+
             ! Define parameters.
             integer(c_intptr_t), value :: platform
             type(c_ptr), value :: func_name
-            
+
         end function
-!            
+!
 !    !
 !    !end interface
 !    !

--- a/makefile
+++ b/makefile
@@ -15,10 +15,10 @@ vpath %.f90 external
 vpath %.f90 external/clfortran
 
 # Source files
-PROGS = 
+PROGS =
 BASE = Focal clfortran Quicksort
 SRCS = Error Memory Query Setup Utils
-LIBS = focal
+LIBS = focal focaldbg
 
 # --- End Configuration ---
 
@@ -73,10 +73,15 @@ $(PREFIX)lib/%: $(LIBDIR)%
 $(BINDIR)%: $(addprefix $(OBJDIR), %.o)
 	$(FC) $^ $(LFLAGS) -o $@
 
-# Generate libraries
-$(LIBDIR)%: $(BASE_OBJS) $(OBJS)
+# Generate release library
+$(LIBDIR)libfocal.a: $(BASE_OBJS) $(OBJS) $(OBJDIR)NoDebug.o
 	rm -f $@
 	$(AR) -cq $@ $^
+
+# Generate debug library
+$(LIBDIR)libfocaldbg.a: $(BASE_OBJS) $(OBJS) $(OBJDIR)Debug.o
+		rm -f $@
+		$(AR) -cq $@ $^
 
 # Compile fortran objects
 $(OBJDIR)%.o: %.f90

--- a/src/Debug.f90
+++ b/src/Debug.f90
@@ -170,4 +170,33 @@ submodule (Focal) Focal_Debug
   ! ---------------------------------------------------------------------------
 
 
+  module procedure fclDbgWait !(event,descrip)
+    !! Wait for an event to complete and check for successful completion.
+    !! Throw runtime error if status is not CL_COMPLETE.
+
+    integer(c_int32_t) :: eStatus
+
+    call fclWait(event)
+
+    call fclGetEventInfo(event,CL_EVENT_COMMAND_EXECUTION_STATUS,eStatus)
+
+    if (eStatus /= CL_COMPLETE) then
+
+      eStatus = -1 * eStatus
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      if (present(descrip)) then
+        write(*,*) ' An event ('//descrip//') has terminated abnormally.'
+      else
+        write(*,*) ' An event has terminated abnormally.'
+      end if
+      write(*,*) ' Error code: ',eStatus,' : ',trim(fclGetErrorString(eStatus))
+
+      call fclRuntimeError('fclDbgWait')
+
+    end if
+
+  end procedure fclDbgWait
+  ! ---------------------------------------------------------------------------
+
+
 end submodule Focal_Debug

--- a/src/Debug.f90
+++ b/src/Debug.f90
@@ -1,0 +1,117 @@
+submodule (Focal) Focal_Debug
+  !! FOCAL: openCL abstraction layer for fortran
+  !!  Implementation module for focal debug routines.
+  !!  This submodule is linked in the debug version of Focal build.
+
+  !! @note This is an implementation submodule: it contains the code implementing the subroutines defined in the
+  !!  corresponding header module file. See header module file (Focal.f90) for interface definitions. @endnote
+  use clfortran
+  implicit none
+
+  contains
+
+  module procedure fclDbgCheckKernelNArg !(kernel,nArg)
+    !! Check that number of actual args matches number of kernel args
+
+    integer :: nKernelArg
+
+    call fclGetKernelInfo(kernel,CL_KERNEL_NUM_ARGS,nKernelArg)
+
+    if (nKernelArg /= nArg) then
+
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      write(*,*) ' Mismatch in number of kernel arguments.'
+      write(*,*) ' Kernel name: ',kernel%name
+      write(*,*) ' Number of kernel arguments: ',nKernelArg
+      write(*,*) ' Number of arguments passed: ',nArg
+      write(*,*)
+
+      call fclRuntimeError('fclDbgCheckKernelNArg')
+
+    end if
+
+  end procedure fclDbgCheckKernelNArg
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclDbgCheckKernelArgType !(kernel,argNo,type)
+
+    character(:), allocatable :: argType
+    call fclGetKernelArgInfo(kernel,argNo,CL_KERNEL_ARG_TYPE_NAME,argType)
+
+    if (index(argType,type) == 0 .or. &
+          index(argType,'*') /= index(type,'*')) then
+
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      write(*,*) ' Mismatch in type of kernel argument.'
+      write(*,*) ' Kernel name: ',kernel%name
+      write(*,*) ' Argument index: ',argNo
+      write(*,*) ' Expecting ',argType,' but got ',type
+      write(*,*)
+
+      call fclRuntimeError('fclDbgCheckKernelArgType')
+
+    end if
+
+  end procedure fclDbgCheckKernelArgType
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclDbgCheckKernelArgQualifier !(kernel,argNo,qualifier)
+
+    integer :: argQual
+    character(10) :: qualStr
+    logical :: matched
+
+    call fclGetKernelArgInfo(kernel,argNo,CL_KERNEL_ARG_ADDRESS_QUALIFIER,argQual)
+    matched = .false.
+
+    select case(argQual)
+
+      case(CL_KERNEL_ARG_ADDRESS_LOCAL)
+        qualStr = 'local'
+        if (index(qualifier,'local') > 0) then
+          matched =.true.
+        end if
+
+      case(CL_KERNEL_ARG_ADDRESS_GLOBAL)
+        qualStr = 'global'
+        if (index(qualifier,'global') > 0) then
+          matched =.true.
+        end if
+
+      case(CL_KERNEL_ARG_ADDRESS_PRIVATE)
+        qualStr = 'private'
+        if (index(qualifier,'private') > 0) then
+          matched =.true.
+        end if
+
+      case(CL_KERNEL_ARG_ADDRESS_CONSTANT)
+        qualStr = 'constant'
+        if (index(qualifier,'constant') > 0) then
+          matched =.true.
+        end if
+
+      case default
+        call fclRuntimeError('fclDbgCheckKernelArgQualifier: unknown qualifier returned by opencl api.')
+
+    end select
+
+    if(.not.matched) then
+
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      write(*,*) ' Mismatch in address space qualifier of kernel argument.'
+      write(*,*) ' Kernel name: ',kernel%name
+      write(*,*) ' Argument index: ',argNo
+      write(*,*) ' Expecting qualifer "',trim(qualStr),'" but given argument was one of "',qualifier,'".'
+      write(*,*)
+
+      call fclRuntimeError('fclDbgCheckKernelArgType')
+
+    end if
+
+  end procedure fclDbgCheckKernelArgQualifier
+  ! ---------------------------------------------------------------------------
+
+
+end submodule Focal_Debug

--- a/src/Debug.f90
+++ b/src/Debug.f90
@@ -10,6 +10,62 @@ submodule (Focal) Focal_Debug
 
   contains
 
+  module procedure fclDbgCheckBufferInit !(memObject,descrip)
+    !! Check that a device buffer object has been initialised.
+
+    if (memObject%nBytes <= 0) then
+
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      write(*,*) ' Attempt to use uninitialised device buffer at: ',descrip
+      write(*,*)
+
+      call fclRuntimeError('fclDbgCheckBufferInit')
+
+    end if
+
+  end procedure fclDbgCheckBufferInit
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclDbgCheckBufferSize !(memObject,hostBytes,descrip)
+    !! Check that a host buffer matches the size in bytes of a device buffer
+
+    if (hostBytes /= memObject%nBytes) then
+
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      write(*,*) ' Mismatch in size between host buffer and device buffer at: ',descrip
+      write(*,*) ' Host buffer size: ',hostBytes
+      write(*,*) ' Device buffer size: ',memObject%nBytes
+      write(*,*)
+
+      call fclRuntimeError('fclDbgCheckBufferSize')
+
+    end if
+
+  end procedure fclDbgCheckBufferSize
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclDbgCheckCopyBufferSize !(memObject1,memObject2)
+    !! Check that device buffers match in size in bytes for copying
+
+    if (memObject1%nBytes /= memObject2%nBytes) then
+
+      write(*,*) '(!) Focal (debug build) runtime assertion failed.'
+      write(*,*) ' Mismatch in size between source buffer and destination buffer'//&
+                  '  while attempting to copy device buffers. (fclMemCopy)'
+      write(*,*) ' Source buffer size: ',memObject2%nBytes
+      write(*,*) ' Destination buffer size: ',memObject1%nBytes
+      write(*,*)
+
+      call fclRuntimeError('fclDbgCheckCopyBufferSize')
+
+    end if
+
+  end procedure fclDbgCheckCopyBufferSize
+  ! ---------------------------------------------------------------------------
+
+
   module procedure fclDbgCheckKernelNArg !(kernel,nArg)
     !! Check that number of actual args matches number of kernel args
 

--- a/src/Error.f90
+++ b/src/Error.f90
@@ -7,20 +7,27 @@ submodule (Focal) Focal_Error
 
   use clfortran
   implicit none
-  
+
   integer, parameter :: CL_PLATFORM_NOT_FOUND_KHR = -1001
     !! Extension error: No valid ICDs found
-  
+
+  interface
+    !! Interface to c function abort().
+    !!  Used to print backtrace on error.
+    subroutine c_abort() bind(C, name="abort")
+    end subroutine
+  end interface
+
   contains
 
   module procedure fclDefaultErrorHandler
-    
+
     if (errcode /= CL_SUCCESS) then
 
       write(*,*) '(!) Fatal openCl error ',errcode,' : ',trim(fclGetErrorString(errcode))
       write(*,*) '      at ',focalCall,':',oclCall
-      
-      stop 1
+
+      call c_abort()
     end if
 
   end procedure fclDefaultErrorHandler
@@ -39,7 +46,7 @@ submodule (Focal) Focal_Error
 
       write(*,*) '(!) Fatal openCl error while building kernel: ',errcode,' : ',trim(fclGetErrorString(errcode))
 
-      ! Iterate over context devices 
+      ! Iterate over context devices
       do i=1,ctx%platform%numDevice
 
         write(*,'(A,I3)') ' Build log for context device ',i
@@ -53,7 +60,7 @@ submodule (Focal) Focal_Error
         allocate(buildLogBuffer(buffLen))
         buffLen = size(buildLogBuffer,1)
 
-        errcode = clGetProgramBuildInfo(prog%cl_program, ctx%platform%cl_device_ids(1), & 
+        errcode = clGetProgramBuildInfo(prog%cl_program, ctx%platform%cl_device_ids(1), &
           CL_PROGRAM_BUILD_LOG, buffLen, c_loc(buildLogBuffer), int32_ret);
 
         call fclErrorHandler(errcode,'fclCompileProgram','clGetProgramBuildInfo')
@@ -65,7 +72,7 @@ submodule (Focal) Focal_Error
 
       end do
 
-      stop
+      stop 1
     end if
 
   end procedure fclHandleBuildError
@@ -119,10 +126,10 @@ submodule (Focal) Focal_Error
 
       case (CL_INVALID_PROGRAM)
         errstr = 'CL_INVALID_PROGRAM'
-        
+
       case (CL_INVALID_ARG_INDEX)
         errstr = 'CL_INVALID_ARG_INDEX'
-        
+
       case (CL_INVALID_ARG_VALUE)
         errstr = 'CL_INVALID_ARG_VALUE'
 
@@ -159,7 +166,8 @@ submodule (Focal) Focal_Error
     if (present(descrip)) then
       write(*,*) '      at ',descrip
     end if
-    stop
+
+    call c_abort()
 
   end procedure fclRuntimeError
   ! ---------------------------------------------------------------------------

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -471,6 +471,57 @@ module Focal
 
   end interface fclGetDeviceInfo
 
+  interface fclGetKernelInfo
+    !! Generic interface to query kernel information.
+    !! See [clGetDeviceInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelInfo.html)
+    !! for values of 'key' argument contained in clfortran module.
+
+    module subroutine fclGetKernelInfoString(kernel,key,value)
+      !! Query kernel information for string info.
+      !! See [clGetPlatformInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelInfo.html)
+      !!  for values of 'key' argument containined in clfortran module.
+      type(fclKernel), intent(in) :: kernel
+      integer(c_int32_t), intent(in) :: key
+      character(:), allocatable, intent(out), target :: value
+    end subroutine fclGetKernelInfoString
+
+    module subroutine fclGetKernelInfoInt32(kernel,key,value)
+      !! Query kernel information for 32bit integer.
+      !! See [clGetPlatformInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelInfo.html)
+      !!  for values of 'key' argument containined in clfortran module.
+      type(fclKernel), intent(in) :: kernel
+      integer(c_int32_t), intent(in) :: key
+      integer(c_int32_t), intent(out), target :: value
+    end subroutine fclGetKernelInfoInt32
+
+  end interface fclGetKernelInfo
+
+  interface fclGetKernelArgInfo
+    !! Generic interface to query kernel argument information.
+    !! See [clGetDeviceInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelArgInfo.html)
+    !! for values of 'key' argument contained in clfortran module.
+
+    module subroutine fclGetKernelArgInfoString(kernel,argNo,key,value)
+      !! Query kernel information for string info.
+      !! See [clGetPlatformInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelArgInfo.html)
+      !!  for values of 'key' argument containined in clfortran module.
+      type(fclKernel), intent(in) :: kernel
+      integer, intent(in) :: argNo
+      integer(c_int32_t), intent(in) :: key
+      character(:), allocatable, intent(out), target :: value
+    end subroutine fclGetKernelArgInfoString
+
+    module subroutine fclGetKernelArgInfoInt32(kernel,argNo,key,value)
+      !! Query kernel information for 32bit integer.
+      !! See [clGetPlatformInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelArgInfo.html)
+      !!  for values of 'key' argument containined in clfortran module.
+      type(fclKernel), intent(in) :: kernel
+      integer, intent(in) :: argNo
+      integer(c_int32_t), intent(in) :: key
+      integer(c_int32_t), intent(out), target :: value
+    end subroutine fclGetKernelArgInfoInt32
+
+  end interface fclGetKernelArgInfo
 
   interface
 

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -53,7 +53,7 @@ module Focal
 
   type :: fclEvent
     !! Type wrapper for OpenCL event pointers
-    type(c_ptr) :: cl_event                          !! OpenCL event pointer
+    integer(c_intptr_t) :: cl_event                          !! OpenCL event pointer
   end type fclEvent
 
   type :: fclCommandQ
@@ -73,7 +73,7 @@ module Focal
       !! Focal event object for the most recent kernel event to be enqueued
     type(fclEvent) :: lastBarrierEvent
       !! Focal event object for the most recent barrier event to be enqueued
-    type(c_ptr), allocatable :: dependencyList(:)
+    integer(c_intptr_t), allocatable :: dependencyList(:)
       !! List of pre-requisite events for next enqueued action.
       !!  All events in this list are used as dependencies for the next enqueued
       !!   operation. At enqueueing, the list is cleared.

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -789,8 +789,30 @@ module Focal
   ! ---------------------------- DEBUG ROUTINES -------------------------------
   interface
 
+    module subroutine fclDbgCheckBufferInit(memObject,descrip)
+      !! Check that a device buffer object has been initialised.
+      !! @note Debug routine: only executed for debug build. @endnote
+      class(fclDeviceBuffer), intent(in) :: memObject
+      character(*), intent(in) :: descrip
+    end subroutine fclDbgCheckBufferInit
+
+    module subroutine fclDbgCheckBufferSize(memObject,hostBytes,descrip)
+      !! Check that a host buffer matches the size in bytes of a device buffer.
+      !! @note Debug routine: only executed for debug build. @endnote
+      class(fclDeviceBuffer), intent(in) :: memObject
+      integer(c_size_t), intent(in) :: hostBytes
+      character(*), intent(in) :: descrip
+    end subroutine fclDbgCheckBufferSize
+
+    module subroutine fclDbgCheckCopyBufferSize(memObject1,memObject2)
+      !! Check that a host buffer matches the size in bytes of a device buffer.
+      !! @note Debug routine: only executed for debug build. @endnote
+      class(fclDeviceBuffer), intent(in) :: memObject1 ! Destination buffer
+      class(fclDeviceBuffer), intent(in) :: memObject2 ! Source buffer
+    end subroutine fclDbgCheckCopyBufferSize
+
     module subroutine fclDbgCheckKernelNArg(kernel,nArg)
-      !! Check that number of actual args matches number of kernel args
+      !! Check that number of actual args matches number of kernel args.
       !! @note Debug routine: only executed for debug build. @endnote
       type(fclKernel), intent(in) :: kernel
       integer, intent(in) :: nArg
@@ -805,7 +827,7 @@ module Focal
     end subroutine fclDbgCheckKernelArgType
 
     module subroutine fclDbgCheckKernelArgQualifier(kernel,argNo,qualifier)
-      !! Checks the address qualifier of arguments passed to kernels
+      !! Checks the address qualifier of arguments passed to kernels.
       !! @note Debug routine: only executed for debug build. @endnote
       type(fclKernel), intent(in) :: kernel
       integer, intent(in) :: argNo

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -847,6 +847,14 @@ module Focal
       character(*), intent(in) :: qualifier
     end subroutine fclDbgCheckKernelArgQualifier
 
+    module subroutine fclDbgWait(event,descrip)
+      !! Wait for an event to complete and check for successful completion.
+      !! Throw runtime error if status is not CL_COMPLETE.
+      !! @note Debug routine: only executed for debug build. @endnote
+      type(fclEvent), intent(in) :: event              !! Event object to check
+      character(*), intent(in), optional :: descrip    !! Description for debugging
+    end subroutine fclDbgWait
+
   end interface
 
 

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -525,6 +525,19 @@ module Focal
 
   interface
 
+    module subroutine fclGetEventInfo(event,key,value)
+      !! Query kernel information for 32bit integer.
+      !! See [clGetPlatformInfo](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelArgInfo.html)
+      !!  for values of 'key' argument containined in clfortran module.
+      type(fclEvent), intent(in) :: event
+      integer(c_int32_t), intent(in) :: key
+      integer(c_int32_t), intent(out), target :: value
+    end subroutine fclGetEventInfo
+
+  end interface
+
+  interface
+
     module function fclGetPlatforms() result(platforms)
       !! Return pointer to array of available fclPlatforms
       type(fclPlatform), pointer :: platforms(:)

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -786,6 +786,36 @@ module Focal
   end interface fclClearDependencies
 
 
+  ! ---------------------------- DEBUG ROUTINES -------------------------------
+  interface
+
+    module subroutine fclDbgCheckKernelNArg(kernel,nArg)
+      !! Check that number of actual args matches number of kernel args
+      !! @note Debug routine: only executed for debug build. @endnote
+      type(fclKernel), intent(in) :: kernel
+      integer, intent(in) :: nArg
+    end subroutine fclDbgCheckKernelNArg
+
+    module subroutine fclDbgCheckKernelArgType(kernel,argNo,type)
+      !! Checks the types of arguments passed to kernels
+      !! @note Debug routine: only executed for debug build. @endnote
+      type(fclKernel), intent(in) :: kernel
+      integer, intent(in) :: argNo
+      character(*), intent(in) :: type
+    end subroutine fclDbgCheckKernelArgType
+
+    module subroutine fclDbgCheckKernelArgQualifier(kernel,argNo,qualifier)
+      !! Checks the address qualifier of arguments passed to kernels
+      !! @note Debug routine: only executed for debug build. @endnote
+      type(fclKernel), intent(in) :: kernel
+      integer, intent(in) :: argNo
+      character(*), intent(in) :: qualifier
+    end subroutine fclDbgCheckKernelArgQualifier
+
+  end interface
+
+
+
   ! ---------------------------- UTILITY ROUTINES -------------------------------
 
   interface

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -126,6 +126,18 @@ module Focal
     integer(c_size_t) :: nBytes                      !! Size of local argument in bytes
   end type fclLocalArgument
 
+  type, extends(fclLocalArgument) :: fclLocalArgInt32
+    !! Type wrapper for local kernel arguments representing 32 bit integers
+  end type fclLocalArgInt32
+
+  type, extends(fclLocalArgument) :: fclLocalArgFloat
+    !! Type wrapper for local kernel arguments representing floats
+  end type fclLocalArgFloat
+
+  type, extends(fclLocalArgument) :: fclLocalArgDouble
+    !! Type wrapper for local kernel arguments representing doubles
+  end type fclLocalArgDouble
+
   ! ---------------------------- ABSTRACT INTERFACES --------------------------
 
   abstract interface
@@ -163,6 +175,7 @@ module Focal
     !! Procedure pointer for custom OpenCL runtime error handler
 
   ! ---------------------------- ERROR ROUTINES -------------------------------
+
   interface
 
     module subroutine fclHandleBuildError(builderrcode,prog,ctx)
@@ -458,6 +471,7 @@ module Focal
 
   end interface fclGetDeviceInfo
 
+
   interface
 
     module function fclGetPlatforms() result(platforms)
@@ -621,19 +635,19 @@ module Focal
     module function fclLocalInt32(nElem) result(localArg)
       !! Create a integer local kernel argument object for launching kernels
       integer, intent(in) :: nElem                   !! No of array elements
-      type(fclLocalArgument) :: localArg             !! Returns local argument object
+      type(fclLocalArgInt32) :: localArg             !! Returns local argument object
     end function fclLocalInt32
 
     module function fclLocalFloat(nElem) result(localArg)
       !! Create a float local kernel argument object for launching kernels
       integer, intent(in) :: nElem                   !! No of array elements
-      type(fclLocalArgument) :: localArg             !! Returns local argument object
+      type(fclLocalArgFloat) :: localArg             !! Returns local argument object
     end function fclLocalFloat
 
     module function fclLocalDouble(nElem) result(localArg)
       !! Create a double local kernel argument object for launching kernels
       integer, intent(in) :: nElem                   !! No of array elements
-      type(fclLocalArgument) :: localArg             !! Returns local argument object
+      type(fclLocalArgDouble) :: localArg            !! Returns local argument object
     end function fclLocalDouble
 
   end interface
@@ -719,6 +733,7 @@ module Focal
     end subroutine fclClearDependencies_2
 
   end interface fclClearDependencies
+
 
   ! ---------------------------- UTILITY ROUTINES -------------------------------
 

--- a/src/Memory.f90
+++ b/src/Memory.f90
@@ -115,6 +115,8 @@ submodule (Focal) Focal_Memory
 
     integer(c_int32_t) :: errcode
 
+    call fclDbgCheckBufferInit(memObject,'fclMemWriteScalar')
+
     errcode = clEnqueueFillBuffer(memObject%cmdq%cl_command_queue, &
                 memObject%cl_mem, hostBufferPtr, nBytesPattern, &
                 int(0,c_size_t), memObject%nBytes, &
@@ -164,6 +166,9 @@ submodule (Focal) Focal_Memory
 
     integer(c_int32_t) :: errcode
     integer(c_int32_t) :: blocking_write
+
+    call fclDbgCheckBufferInit(memObject,'fclMemWrite')
+    call fclDbgCheckBufferSize(memObject,nBytes,'fclMemWrite')
 
     if (memObject%cmdq%blockingWrite) then
       blocking_write = CL_TRUE
@@ -223,6 +228,9 @@ submodule (Focal) Focal_Memory
     integer(c_int32_t) :: errcode
     integer(c_int32_t) :: blocking_read
 
+    call fclDbgCheckBufferInit(memObject,'fclMemRead')
+    call fclDbgCheckBufferSize(memObject,nBytes,'fclMemRead')
+
     if (memObject%cmdq%blockingRead) then
       blocking_read = CL_TRUE
     else
@@ -280,8 +288,6 @@ submodule (Focal) Focal_Memory
 
     integer(c_int32_t) :: errcode
 
-    !! @todo Implement debug check for matching dimensions @endtodo
-
     if (memObject2%nBytes < 0) then
       ! Source object is uninitialised: nothing to copy
 
@@ -298,6 +304,8 @@ submodule (Focal) Focal_Memory
     else
       ! Receiving memory object is initialised
       !  therefore perform a device-to-device copy
+
+      call fclDbgCheckCopyBufferSize(memObject1,memObject2)
 
       errcode = clEnqueueCopyBuffer(memObject1%cmdq%cl_command_queue, &
                 memObject2%cl_mem, memObject1%cl_mem, &
@@ -340,9 +348,13 @@ submodule (Focal) Focal_Memory
 
     integer(c_int32_t) :: errcode
 
-    errcode = clReleaseMemObject(memObject%cl_mem)
+    call fclDbgCheckBufferInit(memObject,'fclFreeBuffer')
 
-    call fclErrorHandler(errcode,'fclBufferFree','clReleaseMemObject')
+    errcode = clReleaseMemObject(memObject%cl_mem)
+    
+    call fclErrorHandler(errcode,'fclFreeBuffer','clReleaseMemObject')
+
+    memObject%nBytes = -1
 
   end procedure fclFreeBuffer
   ! ---------------------------------------------------------------------------

--- a/src/NoDebug.f90
+++ b/src/NoDebug.f90
@@ -10,18 +10,34 @@ submodule (Focal) Focal_NoDebug
 
   contains
 
+  module procedure fclDbgCheckBufferInit !(memObject)
+    !! Check that a device buffer object has been initialised.
+
+  end procedure fclDbgCheckBufferInit
+  ! ---------------------------------------------------------------------------
+
+  module procedure fclDbgCheckBufferSize !(memObject,hostBytes)
+    !! Check that a host buffer matches the size in bytes of a device buffer
+
+  end procedure fclDbgCheckBufferSize
+  ! ---------------------------------------------------------------------------
+
+  module procedure fclDbgCheckCopyBufferSize !(memObject1,memObject2)
+    !! Check that device buffers match in size in bytes for copying
+
+  end procedure fclDbgCheckCopyBufferSize
+  ! ---------------------------------------------------------------------------
+
   module procedure fclDbgCheckKernelNArg !(kernel,nArg)
     !! Check that number of actual args matches number of kernel args
 
   end procedure fclDbgCheckKernelNArg
   ! ---------------------------------------------------------------------------
 
-
   module procedure fclDbgCheckKernelArgType !(kernel,argNo,type)
 
   end procedure fclDbgCheckKernelArgType
   ! ---------------------------------------------------------------------------
-
 
   module procedure fclDbgCheckKernelArgQualifier !(kernel,argNo,qualifier)
 

--- a/src/NoDebug.f90
+++ b/src/NoDebug.f90
@@ -44,4 +44,9 @@ submodule (Focal) Focal_NoDebug
   end procedure fclDbgCheckKernelArgQualifier
   ! ---------------------------------------------------------------------------
 
+  module procedure fclDbgWait !(event,descrip)
+
+  end procedure fclDbgWait
+  ! ---------------------------------------------------------------------------
+
 end submodule Focal_NoDebug

--- a/src/NoDebug.f90
+++ b/src/NoDebug.f90
@@ -1,0 +1,31 @@
+submodule (Focal) Focal_NoDebug
+  !! FOCAL: openCL abstraction layer for fortran
+  !!  Implementation module for focal debug routines.
+  !!  This submodule is linked in the release version of Focal build.
+
+  !! @note This is an implementation submodule: it contains the code implementing the subroutines defined in the
+  !!  corresponding header module file. See header module file (Focal.f90) for interface definitions. @endnote
+
+  implicit none
+
+  contains
+
+  module procedure fclDbgCheckKernelNArg !(kernel,nArg)
+    !! Check that number of actual args matches number of kernel args
+
+  end procedure fclDbgCheckKernelNArg
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclDbgCheckKernelArgType !(kernel,argNo,type)
+
+  end procedure fclDbgCheckKernelArgType
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclDbgCheckKernelArgQualifier !(kernel,argNo,qualifier)
+
+  end procedure fclDbgCheckKernelArgQualifier
+  ! ---------------------------------------------------------------------------
+
+end submodule Focal_NoDebug

--- a/src/Query.f90
+++ b/src/Query.f90
@@ -46,10 +46,10 @@ submodule (Focal) Focal_Query
   end procedure fclGetDeviceInfoString
   ! ---------------------------------------------------------------------------
 
-  
+
   module procedure fclGetDeviceInfoInt32 !(device,key,value)
     ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetDeviceInfo.html
-    
+
     integer(c_int32_t) :: errcode
     integer(c_size_t) :: temp_size, size_ret
 
@@ -63,7 +63,7 @@ submodule (Focal) Focal_Query
 
   module procedure fclGetDeviceInfoInt64 !(device,key,value)
     ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetDeviceInfo.html
-    
+
     integer(c_int32_t) :: errcode
     integer(c_size_t) :: temp_size, size_ret
 
@@ -72,6 +72,74 @@ submodule (Focal) Focal_Query
     call fclErrorHandler(errcode,'fclGetDeviceInfoInt64','clGetDeviceInfo')
 
   end procedure fclGetDeviceInfoInt64
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclGetKernelInfoString !(kernel,key,value)
+    !! Query kernel information for string info.
+    ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetKernelInfo.html
+
+    integer(c_size_t) :: zero_size = 0
+    integer(c_int32_t) :: errcode
+    integer(c_size_t) :: temp_size, size_ret
+
+    errcode = clGetKernelInfo(kernel%cl_kernel, key, zero_size, C_NULL_PTR, temp_size)
+    call fclErrorHandler(errcode,'fclGetKernelInfoString','clGetKernelInfo')
+
+    allocate( character(len=temp_size) :: value)
+    errcode = clGetKernelInfo(kernel%cl_kernel, key, temp_size, C_LOC(value), size_ret)
+    call fclErrorHandler(errcode,'fclGetKernelInfoString','clGetKernelInfo')
+
+  end procedure fclGetKernelInfoString
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclGetKernelInfoInt32 !(kernel,key,value)
+    !! Query kernel information for 32bit integer.
+    ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetKernelInfo.html
+
+    integer(c_int32_t) :: errcode
+    integer(c_size_t) :: temp_size, size_ret
+
+    temp_size = c_sizeof(int(1,c_int32_t))
+    errcode = clGetKernelInfo(kernel%cl_kernel, key, temp_size, C_LOC(value), size_ret)
+    call fclErrorHandler(errcode,'fclGetKernelInfoInt32','clGetKernelInfo')
+
+  end procedure fclGetKernelInfoInt32
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclGetKernelArgInfoString !(kernel,key,value)
+    !! Query kernel argument information for string info.
+    ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetKernelArgInfo.html
+
+    integer(c_size_t) :: zero_size = 0
+    integer(c_int32_t) :: errcode
+    integer(c_size_t) :: temp_size, size_ret
+
+    errcode = clGetKernelArgInfo(kernel%cl_kernel, argNo, key, zero_size, C_NULL_PTR, temp_size)
+    call fclErrorHandler(errcode,'fclGetKernelArgInfoString','clGetKernelArgInfo')
+
+    allocate( character(len=temp_size) :: value)
+    errcode = clGetKernelArgInfo(kernel%cl_kernel, argNo, key, temp_size, C_LOC(value), size_ret)
+    call fclErrorHandler(errcode,'fclGetKernelArgInfoString','clGetKernelArgInfo')
+
+  end procedure fclGetKernelArgInfoString
+  ! ---------------------------------------------------------------------------
+
+
+  module procedure fclGetKernelArgInfoInt32 !(kernel,argNo,key,value)
+    !! Query kernel argument information for 32bit integer.
+    ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetKernelArgInfo.html
+
+    integer(c_int32_t) :: errcode
+    integer(c_size_t) :: temp_size, size_ret
+
+    temp_size = c_sizeof(int(1,c_int32_t))
+    errcode = clGetKernelArgInfo(kernel%cl_kernel, argNo, key, temp_size, C_LOC(value), size_ret)
+    call fclErrorHandler(errcode,'fclGetKernelInfoInt32','clGetKernelInfo')
+
+  end procedure fclGetKernelArgInfoInt32
   ! ---------------------------------------------------------------------------
 
 
@@ -93,7 +161,7 @@ submodule (Focal) Focal_Query
     ! Populate platform_ids array
     errcode = clGetPlatformIDs(num_platforms,c_loc(platform_ids),int32_ret)
     call fclErrorHandler(errcode,'fclGetPlatforms','clGetPlatformIDs')
-    
+
     ! Populate output fclPlatform structure array
     allocate(platforms(num_platforms))
 
@@ -166,7 +234,7 @@ submodule (Focal) Focal_Query
 
   end procedure fclGetDevice
   ! ---------------------------------------------------------------------------
-  
-  
+
+
 
 end submodule Focal_Query

--- a/src/Query.f90
+++ b/src/Query.f90
@@ -143,6 +143,21 @@ submodule (Focal) Focal_Query
   ! ---------------------------------------------------------------------------
 
 
+  module procedure fclGetEventInfo !(event,key,value)
+    !! Query event information for 32bit integer.
+    ! https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetEventInfo.html
+
+    integer(c_int32_t) :: errcode
+    integer(c_size_t) :: temp_size, size_ret
+
+    temp_size = c_sizeof(int(1,c_int32_t))
+    errcode = clGetEventInfo(event%cl_event, key, temp_size, C_LOC(value), size_ret)
+    call fclErrorHandler(errcode,'fclGetEventInfo','clGetEventInfo')
+
+  end procedure fclGetEventInfo
+  ! ---------------------------------------------------------------------------
+
+
   module procedure fclGetPlatforms !result(platforms)
 
     integer :: i

--- a/src/Setup.f90
+++ b/src/Setup.f90
@@ -453,24 +453,28 @@ submodule (Focal) Focal_Setup
         argPtr = c_loc(arg%cl_mem)
         argSize = c_sizeof(arg%cl_mem)
         call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+        call fclDbgCheckBufferInit(arg,'fclSetKernelArg')
 
       class is (fclDeviceInt32)
         argPtr = c_loc(arg%cl_mem)
         argSize = c_sizeof(arg%cl_mem)
         call fclDbgCheckKernelArgType(kernel,argIndex,'int*')
         call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+        call fclDbgCheckBufferInit(arg,'fclSetKernelArg')
 
       class is (fclDeviceFloat)
         argPtr = c_loc(arg%cl_mem)
         argSize = c_sizeof(arg%cl_mem)
         call fclDbgCheckKernelArgType(kernel,argIndex,'float*')
         call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+        call fclDbgCheckBufferInit(arg,'fclSetKernelArg')
 
       class is (fclDeviceDouble)
         argPtr = c_loc(arg%cl_mem)
         argSize = c_sizeof(arg%cl_mem)
         call fclDbgCheckKernelArgType(kernel,argIndex,'double*')
         call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+        call fclDbgCheckBufferInit(arg,'fclSetKernelArg')
 
       class is (fclLocalArgument)
         argPtr = C_NULL_PTR

--- a/src/Setup.f90
+++ b/src/Setup.f90
@@ -616,7 +616,7 @@ submodule (Focal) Focal_Setup
     !! Wait on host for set of events
     integer :: i
     integer(c_int32_t) :: errcode
-    type(c_ptr), target :: cl_eventList(size(eventList,1))
+    integer(c_intptr_t), target :: cl_eventList(size(eventList,1))
 
     ! Populate array of c_ptr
     cl_eventList = [(eventList(i)%cl_event,i=1,size(eventList,1))]

--- a/src/Setup.f90
+++ b/src/Setup.f90
@@ -230,7 +230,7 @@ submodule (Focal) Focal_Setup
 
 
   module procedure fclCreateCommandQ_2 !(device,enableProfiling,outOfOrderExec,&
-                                         !blockingWrite,blockingRead) result(cmdq) 
+                                         !blockingWrite,blockingRead) result(cmdq)
     !! Create a command queue with a Focal device object using default context
     cmdq = fclCreateCommandQ_1(fclDefaultCtx,device,enableProfiling,outOfOrderExec, &
                                            blockingWrite,blockingRead)
@@ -329,7 +329,7 @@ submodule (Focal) Focal_Setup
     integer(c_int32_t) :: errcode
     type(fclCommandQ), pointer :: cmdQ
     type(c_ptr) :: localSizePtr
-    integer :: i0
+    integer :: i0, nArg
 
     ! Check global size has been set
     if (sum(abs(kernel%global_work_size)) == 0) then
@@ -347,6 +347,7 @@ submodule (Focal) Focal_Setup
     !! @todo Debug (runtime) check number of kernel arguments @endtodo
 
     ! --- Check if command queue was specified ---
+    nArg = 0
     i0 = 0
     cmdQ => fclDefaultCmdQ
     if (present(a0)) then
@@ -361,6 +362,7 @@ submodule (Focal) Focal_Setup
         !! First arg is not cmdQ: then it is a kernel arg
         call fclSetKernelArg(kernel,0,arg)
         i0 = 1
+        nArg = nArg + 1
 
       end select
     end if
@@ -368,33 +370,48 @@ submodule (Focal) Focal_Setup
     ! --- Set arguments ---
     if (present(a1)) then
       call fclSetKernelArg(kernel,i0+0,a1)
+      nArg = nArg + 1
     end if
     if (present(a2)) then
       call fclSetKernelArg(kernel,i0+1,a2)
+      nArg = nArg + 1
     end if
     if (present(a3)) then
       call fclSetKernelArg(kernel,i0+2,a3)
+      nArg = nArg + 1
     end if
     if (present(a4)) then
       call fclSetKernelArg(kernel,i0+3,a4)
+      nArg = nArg + 1
     end if
     if (present(a5)) then
       call fclSetKernelArg(kernel,i0+4,a5)
+      nArg = nArg + 1
     end if
     if (present(a6)) then
       call fclSetKernelArg(kernel,i0+5,a6)
+      nArg = nArg + 1
     end if
     if (present(a7)) then
       call fclSetKernelArg(kernel,i0+6,a7)
+      nArg = nArg + 1
     end if
     if (present(a8)) then
       call fclSetKernelArg(kernel,i0+7,a8)
+      nArg = nArg + 1
     end if
     if (present(a9)) then
       call fclSetKernelArg(kernel,i0+8,a9)
+      nArg = nArg + 1
     end if
     if (present(a10)) then
       call fclSetKernelArg(kernel,i0+9,a10)
+      nArg = nArg + 1
+    end if
+
+    if (nArg > 0) then
+      ! If any kernel arguments are specified, check that they are all present
+      call fclDbgCheckKernelNArg(kernel,nArg)
     end if
 
     errcode = clEnqueueNDRangeKernel(cmdq%cl_command_queue, &
@@ -432,25 +449,69 @@ submodule (Focal) Focal_Setup
 
     select type(arg => argValue)
 
-      class is (fclDeviceBuffer)
+    class is (fclDeviceBuffer)
         argPtr = c_loc(arg%cl_mem)
         argSize = c_sizeof(arg%cl_mem)
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+
+      class is (fclDeviceInt32)
+        argPtr = c_loc(arg%cl_mem)
+        argSize = c_sizeof(arg%cl_mem)
+        call fclDbgCheckKernelArgType(kernel,argIndex,'int*')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+
+      class is (fclDeviceFloat)
+        argPtr = c_loc(arg%cl_mem)
+        argSize = c_sizeof(arg%cl_mem)
+        call fclDbgCheckKernelArgType(kernel,argIndex,'float*')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
+
+      class is (fclDeviceDouble)
+        argPtr = c_loc(arg%cl_mem)
+        argSize = c_sizeof(arg%cl_mem)
+        call fclDbgCheckKernelArgType(kernel,argIndex,'double*')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'global,constant')
 
       class is (fclLocalArgument)
         argPtr = C_NULL_PTR
         argSize = arg%nBytes
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'local')
+
+      class is (fclLocalArgInt32)
+        argPtr = C_NULL_PTR
+        argSize = arg%nBytes
+        call fclDbgCheckKernelArgType(kernel,argIndex,'int*')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'local')
+
+      class is (fclLocalArgFloat)
+        argPtr = C_NULL_PTR
+        argSize = arg%nBytes
+        call fclDbgCheckKernelArgType(kernel,argIndex,'float*')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'local')
+
+      class is (fclLocalArgDouble)
+        argPtr = C_NULL_PTR
+        argSize = arg%nBytes
+        call fclDbgCheckKernelArgType(kernel,argIndex,'double*')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'local')
 
       type is (integer(c_int32_t))
         argPtr = c_loc(arg)
         argSize = c_sizeof(int(1,c_int32_t))
+        call fclDbgCheckKernelArgType(kernel,argIndex,'int')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'private')
 
       type is (real(c_float))
         argPtr = c_loc(arg)
         argSize = c_sizeof(real(1.0,c_float))
+        call fclDbgCheckKernelArgType(kernel,argIndex,'float')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'private')
 
       type is (real(c_double))
         argPtr = c_loc(arg)
         argSize = c_sizeof(real(1.0d0,c_double))
+        call fclDbgCheckKernelArgType(kernel,argIndex,'double')
+        call fclDbgCheckKernelArgQualifier(kernel,argIndex,'private')
 
       class default
         write(*,*) 'Kernel name: ',trim(kernel%name)


### PR DESCRIPTION
Adds dual library build with additional 'debug' version.
Debug library contains additional runtime checks for program validity.
Also changed Fortran type for cl_event to c_intptr_t.
Added call to c function 'abort()' to dump stacktrace on errors.
Minor additions to external/clfortran for clGetEventInfo call.