### PR TITLE
v1.0.1 minor update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,54 @@
+# Changes
+
+Most recent release shown first.
+
+## Release v1.0.1
+*Backwards-compatible update.*
+__Date:__ 29/05/2020
+
+__Add: reference counting for fclEvent objects__
+Uses overloaded assignment and finalisation routines
+to call OpenCL reference counting routines for the
+underlying event objects.
+This is needed for when library users store their
+own copies of event objects for dependency management
+and fixes a bug where event objects were invalid.
+
+__Add: deallocation routines for pinned host memory__
+A global variable is used to keep track of device pointers
+that correspond to host mapped memory and which are needed
+for the unmap command during deallocation.
+Also add clWaitForEvents to fclAllocHost and fclFreeHost
+to make these commands host blocking.
+Also removed old 2D array interfaces from header module.
+
+__Update: tests__
+
+
+## Release v1.0.0
+*First stable release.*
+__Date:__ 16/03/20
+__Commit:__ a108d3de720a5745817cc93760cbe6617edc4232
+
+### Incompatible changes
+(Incompatible with previous unversioned beta code)
+
+- Update buffer initialisation interface to be generic subroutine
+
+### New features and enhancements
+These changes do not affect existing interfaces from the pre-release version.
+
+- Add _fclCommandQPool_ object for handling multiple command queues
+- Automatically make sure global dims are multiples of local dims at kernel launch
+- Get ifort build working 
+- Add interfaces for creating sub-buffers
+- Add `fclInit()` quick context setup function
+- Allow device filtering based on supported features
+- Incorporate reference counting of OpenCL events to avoid excessive memory growth
+- Add support for OpenCL user events
+- Populate all OpenCL 1.2 error codes
+- Add copyright and license headers to library source files 
+- Add continuous integration to run tests
+- Add test code coverage check to CI
+
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ __Key features:__
 * Contains built-in 'debug' mode for checking program correctness
 * Contains build-in routines for collecting and presented profiling information
 
-__Project status:__ v1.0.0 stable release
+__Project status:__ v1.0.1 stable release
 
 __Documentation__: [lkedward.github.io/focal-docs](https://lkedward.github.io/focal-docs/)
 

--- a/src/Focal.f90
+++ b/src/Focal.f90
@@ -92,6 +92,8 @@ module Focal
     type :: fclEvent
     !! Type wrapper for OpenCL event pointers
     integer(c_intptr_t) :: cl_event = -1             !! OpenCL event pointer
+    contains
+      final :: fclReleaseEvent                       !! Decrement cl reference counter
   end type fclEvent
 
   type :: fclCommandQ
@@ -1394,6 +1396,31 @@ module Focal
     end subroutine fclWaitEventList
 
   end interface fclWait
+
+  interface assignment(=)
+
+    module subroutine fclEventCopy(target,source)
+      !! Overloaded assignment for event assignment.
+      !!  Handles opencl reference counting for the underlying event object
+      type(fclEvent), intent(inout) :: target
+      type(fclEvent), intent(in) :: source
+    end subroutine fclEventCopy
+
+  end interface
+    
+  interface 
+
+    module subroutine fclReleaseEvent(event)
+      !! Light weight wrapper for clReleaseEvent (decrement reference count)
+      type(fclEvent), intent(in) :: event               !! Focal event object to release
+    end subroutine fclReleaseEvent
+
+    module subroutine fclRetainEvent(event)
+      !! Light weight wrapper for clRetainEvent (increment reference count)
+      type(fclEvent), intent(in) :: event               !! Focal event object to retain
+    end subroutine fclRetainEvent
+
+  end interface
 
   interface fclSetDependency
     !! Generic interface to set pre-requisite events for the next enqueued action.

--- a/src/Focal_Profile.f90
+++ b/src/Focal_Profile.f90
@@ -191,10 +191,6 @@ submodule (Focal) Focal_Profile
       return
     end if
 
-    ! Increment event reference counter
-    errcode = clRetainEvent(event%cl_event)
-    call fclErrorHandler(errcode,'fclSetDependencyEvent','clRetainEvent')
-
     ! Save event
     container%profileEvents(container%nProfileEvent) = event
 

--- a/test/testPinnedMemory.f90
+++ b/test/testPinnedMemory.f90
@@ -92,6 +92,15 @@ call fclTestAssertEqual(hostReal64_1,hostReal64_2,'hostReal64_1 == hostReal64_2 
 call fclTestAssertEqual(hostInt32_1,hostInt32_2,'hostInt32_1 == hostInt32_2 (1)')
 call fclTestAssertEqual(hostChar_1,hostChar_2,'hostChar_1 == hostChar_2 (1)')
 
+! --- Deallocate pinned memory ---
+call fclFreeHost(hostReal32_1)
+call fclFreeHost(hostReal32_2)
+call fclFreeHost(hostReal64_1)
+call fclFreeHost(hostReal64_2)
+call fclFreeHost(hostInt32_1)
+call fclFreeHost(hostInt32_2)
+call fclFreeHost(char_ptr_1)
+call fclFreeHost(char_ptr_2)
 call fclTestFinish()
 
 end program testPinnedMemory

--- a/test/testPinnedMemory.f90
+++ b/test/testPinnedMemory.f90
@@ -92,6 +92,16 @@ call fclTestAssertEqual(hostReal64_1,hostReal64_2,'hostReal64_1 == hostReal64_2 
 call fclTestAssertEqual(hostInt32_1,hostInt32_2,'hostInt32_1 == hostInt32_2 (1)')
 call fclTestAssertEqual(hostChar_1,hostChar_2,'hostChar_1 == hostChar_2 (1)')
 
+! --- Deallocate device memory ---
+call fclFreeBuffer(deviceInt32_1)
+call fclFreeBuffer(deviceInt32_2)
+call fclFreeBuffer(deviceReal32_1)
+call fclFreeBuffer(deviceReal32_2)
+call fclFreeBuffer(deviceReal64_1)
+call fclFreeBuffer(deviceReal64_2)
+call fclFreeBuffer(deviceBuffer_1)
+call fclFreeBuffer(deviceBuffer_2)
+
 ! --- Deallocate pinned memory ---
 call fclFreeHost(hostReal32_1)
 call fclFreeHost(hostReal32_2)

--- a/test/testSubBuffers.f90
+++ b/test/testSubBuffers.f90
@@ -84,6 +84,15 @@ call fclTestAssertEqual(hostReal64_1,hostReal64_2,'hostReal64_1 == hostReal64_2'
 call fclTestAssertEqual(hostInt32_1,hostInt32_2,'hostInt32_1 == hostInt32_2')
 call fclTestAssertEqual(hostChar_1,hostChar_2,'hostChar_1 == hostChar_2')
 
+call fclFreeBuffer(deviceInt32_1)
+call fclFreeBuffer(deviceInt32_2)
+call fclFreeBuffer(deviceReal32_1)
+call fclFreeBuffer(deviceReal32_2)
+call fclFreeBuffer(deviceReal64_1)
+call fclFreeBuffer(deviceReal64_2)
+call fclFreeBuffer(deviceBuffer_1)
+call fclFreeBuffer(deviceBuffer_2)
+
 call fclTestFinish()
 
 end program testSubBuffers


### PR DESCRIPTION
Backwards compatible minor update.
- Add reference counting to fclEvent objects - fixes
error where they are released prematurely.
- Add correct deallocation routines for pinned host memory