### PR TITLE
Fix Intel test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         ./bin/nbody
 
   Intel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v1


### PR DESCRIPTION
Pin runner to `ubuntu-18.04`